### PR TITLE
up timeout

### DIFF
--- a/query_rest.go
+++ b/query_rest.go
@@ -3,7 +3,6 @@ package neutrino
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"time"
@@ -16,7 +15,7 @@ func (s *ChainService) queryRestPeers(query *cfiltersQuery) {
 	client := &http.Client{}
 	validPeers := make([]int, 0, len(s.restPeers))
 	for i, p := range s.restPeers {
-		if p.failures == 0 || time.Since(p.lastFailure) > QueryBatchTimeout {
+		if p.failures == 0 || time.Since(p.lastFailure) > 10*time.Second {
 			validPeers = append(validPeers, i)
 		}
 	}
@@ -24,6 +23,7 @@ func (s *ChainService) queryRestPeers(query *cfiltersQuery) {
 		log.Errorf("queryRestPeers - No valid rest peer")
 		return
 	}
+	// #nosec G404 -- No need to have true randomness when selecting restpeer.
 	restPeerIndex := validPeers[rand.Intn(len(validPeers))]
 	URL := fmt.Sprintf("%v/rest/blockfilter/basic/%v.bin?count=%v", s.restPeers[restPeerIndex].URL, query.stopHash.String(), query.stopHeight-query.startHeight+1)
 	log.Infof("getting %v filters from height %v to height %v, using URL: %v", query.stopHeight-query.startHeight+1, query.startHeight, query.stopHeight, URL)
@@ -39,7 +39,7 @@ func (s *ChainService) queryRestPeers(query *cfiltersQuery) {
 		s.restPeers[restPeerIndex].failures++
 		s.restPeers[restPeerIndex].lastFailure = time.Now()
 		log.Errorf("queryRestPeers - Get (%v) status != OK: %v", URL, res.Status)
-		_, err = io.Copy(ioutil.Discard, res.Body)
+		_, err = io.Copy(io.Discard, res.Body)
 		if err != nil {
 			log.Errorf("error in io.Copy: %v", err)
 		}

--- a/query_rest.go
+++ b/query_rest.go
@@ -13,10 +13,10 @@ import (
 
 func (s *ChainService) queryRestPeers(query *cfiltersQuery) {
 	quit := make(chan struct{})
-	client := &http.Client{Timeout: QueryTimeout}
+	client := &http.Client{}
 	validPeers := make([]int, 0, len(s.restPeers))
 	for i, p := range s.restPeers {
-		if p.failures == 0 || time.Since(p.lastFailure) > 10*time.Second {
+		if p.failures == 0 || time.Since(p.lastFailure) > QueryBatchTimeout {
 			validPeers = append(validPeers, i)
 		}
 	}


### PR DESCRIPTION
# About pr

Remove timeout for the `http.Client` 

Up the timeout to 30 seconds = `QueryBatchTimeout` if there is an error querying the server. 

Do we wish to remove the checking of the time since last failure all together ?
https://github.com/breez/neutrino/blob/43d92434882db0e392980a1a20099f109937115d/query_rest.go#L19