### PR TITLE
Separate ranking for rest supported requests

### DIFF
--- a/neutrino.go
+++ b/neutrino.go
@@ -747,6 +747,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		RestPeers:      cfg.RestPeers,
 		NewWorker:      query.NewWorker,
 		Ranking:        query.NewPeerRanking(),
+		RestRanking:    query.NewPeerRanking(),
 	})
 
 	var err error

--- a/query/peer_rank_test.go
+++ b/query/peer_rank_test.go
@@ -15,7 +15,7 @@ func TestPeerRank(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		p := fmt.Sprintf("peer%d", i)
 		peers = append(peers, p)
-		ranking.AddPeer(p)
+		ranking.AddPeer(p, false)
 	}
 
 	// We'll try to order half of the peers.

--- a/query/workmanager.go
+++ b/query/workmanager.go
@@ -58,7 +58,7 @@ type Worker interface {
 // that is used to determine which peers to prioritize querios on.
 type PeerRanking interface {
 	// AddPeer adds a peer to the ranking.
-	AddPeer(peer string)
+	AddPeer(peer string, prefer bool)
 
 	// Reward should be called when the peer has succeeded in a query,
 	// increasing the likelihood that it will be picked for subsequent
@@ -228,7 +228,7 @@ func (w *peerWorkManager) workDispatcher() {
 			onExit:    onExit,
 		}
 
-		w.cfg.Ranking.AddPeer(restPeer.Addr())
+		w.cfg.Ranking.AddPeer(restPeer.Addr(), true)
 
 		w.wg.Add(1)
 		go func() {
@@ -317,7 +317,7 @@ Loop:
 				onExit:    onExit,
 			}
 
-			w.cfg.Ranking.AddPeer(peer.Addr())
+			w.cfg.Ranking.AddPeer(peer.Addr(), false)
 
 			w.wg.Add(1)
 			go func() {

--- a/query/workmanager_test.go
+++ b/query/workmanager_test.go
@@ -48,7 +48,7 @@ type mockPeerRanking struct {
 
 var _ PeerRanking = (*mockPeerRanking)(nil)
 
-func (p *mockPeerRanking) AddPeer(peer string) {
+func (p *mockPeerRanking) AddPeer(peer string, prefer bool) {
 }
 
 func (p *mockPeerRanking) Order(peers []string) {

--- a/query/workmanager_test.go
+++ b/query/workmanager_test.go
@@ -90,7 +90,8 @@ func startWorkManager(t *testing.T, numWorkers int) (WorkManager,
 			workerChan <- m
 			return m
 		},
-		Ranking: &mockPeerRanking{},
+		Ranking:     &mockPeerRanking{},
+		RestRanking: &mockPeerRanking{},
 	})
 
 	// Start the work manager.


### PR DESCRIPTION
Any rest supported request will be ranked separately.

Previously, the p2p peer may get favored also for rest supported requests, because it is doing other queries not supported by the rest peer like `cfheaders`. These other requests will cause the p2p peer to be preferred if it answered them correctly. By using separate rankings for rest supported requests and non-rest supported requests, the rest peer is fairly ranked.